### PR TITLE
Add .resource as an accepted filetype extension

### DIFF
--- a/lib/autocomplete-plus-provider.js
+++ b/lib/autocomplete-plus-provider.js
@@ -92,7 +92,7 @@ function processFile(path, name, stat, settings) {
 
 function readConfig(){
   let settings = {
-    robotExtensions: ['.robot', '.txt'],
+    robotExtensions: ['.robot', '.txt', '.resource'],
     debug: undefined,              // True/false for verbose console output
     maxFileSize: undefined,        // Files bigger than this will not be loaded in memory
     maxKeywordsSuggestionsCap: undefined,  // Maximum number of suggested keywords


### PR DESCRIPTION
Since `.resource` is recognized officially by robot this should be accepted here too.

http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#resource-and-variable-files

Signed-off-by: Corbin Weidner <corbin.weidner@gtri.gatech.edu>